### PR TITLE
fix regex match for lower case create statement 

### DIFF
--- a/dbgpt_hub/data_process/sql_data_process.py
+++ b/dbgpt_hub/data_process/sql_data_process.py
@@ -159,7 +159,7 @@ class ProcessSqlData:
                         with open(schema_file_path, "r") as file:
                             schema_content = file.read()
                         create_statements = re.findall(
-                            r"CREATE\s.*?;", schema_content, re.DOTALL
+                            r"CREATE\s.*?;", schema_content, re.DOTALL|re.IGNORECASE
                         )
                         input = {
                             "db_id": data[db_id_name],


### PR DESCRIPTION
The current `dbgpt_hub/data_process/sql_data_process.py` script does not consider there actually exists lowercase create statements in the spider dataset. For example, `activity_1/schema.sql` contains `create table Activity ...` which is not captured by the `r"CREATE\s.*?;"` pattern in [line of code here](https://github.com/eosphoros-ai/DB-GPT-Hub/blob/f7187bf2ce514fd4abe6b4b19b18f46088dbcacf/dbgpt_hub/data_process/sql_data_process.py#L162). The consequence is that some samples in the `example_text2sql_dev.json` have blank Instruction field.


This pull request makes the specific pattern case-insensitive to fix this problem. 

```
create_statements = re.findall(
    r"CREATE\s.*?;", schema_content, re.DOTALL**|re.IGNORECASE**
)
```
